### PR TITLE
Fikset treg første request når kjører lokalt

### DIFF
--- a/src/backend/dekorator.ts
+++ b/src/backend/dekorator.ts
@@ -40,6 +40,7 @@ const getDecorator = (): Promise<DekoratørRespons> =>
             NAV_FOOTER: document.getElementById('footer-withmenu')[prop],
           };
           cache.set('main-cache', data);
+          resolve(data);
         } else {
           reject(new Error(error));
         }


### PR DESCRIPTION
Tidligere har dekoratøren kun blitt laget i minne ved første request til serveren. Dette har gjort at første requesten til siden aldri blir løst siden dekoratoren aldri blir returnert. Nå returners dekoratoren i tillegg til å lagres i minne, noe som gjør første requesten blir løst. 