### PR TITLE
Kvitteringsiden skal oppsummere innsendte dokumenter.

### DIFF
--- a/src/frontend/komponenter/Ettersendingsoversikt.tsx
+++ b/src/frontend/komponenter/Ettersendingsoversikt.tsx
@@ -26,7 +26,7 @@ import { Oppsummering } from './Oppsummering';
 import { InnsendingSide } from './InnsendingSide';
 import Stegindikator from 'nav-frontend-stegindikator';
 import { slåSammenSøknadOgEttersendinger } from '../utils/søknadshåndtering';
-import { logDokumentasjonsbehov } from '../utils/amplitude';
+import { logDokumentasjonsbehov, logSidevisning } from '../utils/amplitude';
 import { EOppsummeringstitler } from '../utils/oppsummeringssteg';
 import KnappMedPadding from '../nav-komponenter/Knapp';
 
@@ -80,6 +80,16 @@ const Ettersendingsoversikt: React.FC = () => {
       index: 2,
     },
   ];
+
+  useEffect(() => {
+    if (aktivtSteg === 0) {
+      logSidevisning('Forside');
+    } else if (aktivtSteg === 1) {
+      logSidevisning('Oppsummering');
+    } else if (aktivtSteg === 2) {
+      logSidevisning('Kvittering');
+    }
+  }, [aktivtSteg]);
 
   const oppdaterInnsending = (innsending: IDokumentasjonsbehov) => {
     settEttersending((prevEttersending) => {

--- a/src/frontend/komponenter/InnsendingSide.tsx
+++ b/src/frontend/komponenter/InnsendingSide.tsx
@@ -4,7 +4,6 @@ import { EkstraDokumentasjonsbehovBoks } from './EkstraDokumentasjonsbehovBoks';
 import { LeggTilInnsending } from './LeggTilInnsending';
 import { IDokumentasjonsbehov, IEttersending } from '../typer/ettersending';
 import styled from 'styled-components';
-import { logSidevisning } from '../utils/amplitude';
 import KnappMedPadding from '../nav-komponenter/Knapp';
 
 interface IProps {
@@ -40,8 +39,6 @@ export const InnsendingSide: React.FC<IProps> = ({
   visOppsummering,
   ekstraInnsendingerUtenVedlegg,
 }: IProps) => {
-  logSidevisning('Forside');
-
   return (
     <>
       {ettersending.dokumentasjonsbehov

--- a/src/frontend/komponenter/Oppsummering.tsx
+++ b/src/frontend/komponenter/Oppsummering.tsx
@@ -5,8 +5,6 @@ import { IDokumentasjonsbehov } from '../typer/ettersending';
 import { stønadTypeTilTekst } from '../typer/stønad';
 import OpplastedeVedleggOversikt from './OpplastedeVedleggOversikt';
 import { formaterIsoDato } from '../../shared-utils/dato';
-import { logSidevisning } from '../utils/amplitude';
-import { EOppsummeringstitler } from '../utils/oppsummeringssteg';
 
 const StyledDiv = styled.div`
   margin-top: 2rem;
@@ -22,12 +20,6 @@ export const Oppsummering: React.FC<IProps> = ({
   innsendinger,
   tittel,
 }: IProps) => {
-  if (tittel === EOppsummeringstitler.Innsending) {
-    logSidevisning('Oppsummering');
-  } else if (tittel === EOppsummeringstitler.Kvittering) {
-    logSidevisning('Kvittering');
-  }
-
   return (
     <div>
       <Undertittel>{tittel}</Undertittel>


### PR DESCRIPTION
En bug med useMemo gjorde at visningen av innsendte dokumenter ikke fungerte på innsendingsiden.

[Favro-kort](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8173)