### PR TITLE
Legacy - fjerne deprecated work flow variabler fra build & deploy 

### DIFF
--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -34,8 +34,6 @@ jobs:
         id: docker-build-push
         with:
           team: teamfamilie
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}
   deploy:

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -34,8 +34,6 @@ jobs:
         id: docker-build-push
         with:
           team: teamfamilie
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}
   deploy:


### PR DESCRIPTION
# Fjerne deprecated work flow variabler fra build & deploy 

### Hvorfor er denne endringen nødvendig? ✨ 

Denne PRen prøver å fjerne deprecated work flow variabler fra bygg og deploy taskene. NAIS har satt og `identity_provider` og `project_id` deprecated og skal fjernes, da alle setter de samme verdiene her og utledes derfor automatisk av nais-plattformen nå. Workflows med disse parameterene satt vil ikke lenger virke etter 3. mars.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24100).

### Verdt å nevne

Dette er en av mange PRer der denne samme endringen gjøres for repoer tilhørende enslig-forsørger. 