### PR TITLE
Refaktorering build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,33 +3,13 @@ on:
   workflow_dispatch:
   pull_request:
 
-jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6.3.0
-        with:
-          node-version: 24
-          cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-      - name: Installer npm-avhengigheter
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-        run: npm ci
-      - name: Kjør ESLint
-        run: npm run lint
+permissions:
+  contents: read
 
+jobs:
   build:
-    name: Build
+    name: Lint og bygg
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
         with:
@@ -43,6 +23,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         run: npm ci
+      - name: Kjør ESLint
+        run: npm run lint
       - name: Bygg applikasjon
-        run: |
-          npm run build
+        run: npm run build


### PR DESCRIPTION
- Slår sammen lint og build jobb for å unngå ekstra npm ci, det går raskerer og er billigere.
- Flytter permissions til toppnivå for bedre struktur og gjør det likt som deploy workflows.
- Kjører lint før build - unngår å bygge hvis lint feiler.

Spørsmål: Burde navn på workflow of fil endres?