### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -43,10 +43,10 @@ spec:
         - host: nav.no
   resources:
     limits:
-      memory: 512Mi
+      memory: 128Mi
     requests:
-      memory: 512Mi
-      cpu: 20m
+      memory: 128Mi
+      cpu: 50m
   env:
     - name: APP_VERSION
       value: '{{version}}'

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -43,10 +43,10 @@ spec:
         - host: nav.no
   resources:
     limits:
-      memory: 1024Mi
+      memory: 192Mi
     requests:
-      memory: 1024Mi
-      cpu: 100m
+      memory: 192Mi
+      cpu: 50m
   env:
     - name: APP_VERSION
       value: '{{version}}'


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.