### PR TITLE
Fikse lokal kjøring

### DIFF
--- a/src/backend/dekorator.ts
+++ b/src/backend/dekorator.ts
@@ -28,7 +28,7 @@ export const indexHandler: RequestHandler = async (req, res) => {
   }
 };
 
-const getHtmlWithDecorator = (filePath: string) => {
+const getHtmlWithDecorator = async (filePath: string) => {
   const env = environment().dekoratørEnv;
   if (env === undefined) {
     logger.error('Mangler miljø for dekoratøren');
@@ -47,6 +47,7 @@ const getHtmlWithDecorator = (filePath: string) => {
     },
   };
 
-  return injectDecoratorServerSide(dekoratørConfig);
+  const html = await injectDecoratorServerSide(dekoratørConfig);
+  return html.replace(/<\/link>/g, '');
 };
 export default indexHandler;

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -17,15 +17,6 @@ async function startServer() {
 
   app.use(routes());
 
-  if (process.env.NODE_ENV !== 'development') {
-    app.use(
-      '/familie/alene-med-barn/ettersending/',
-      express.static(frontendMappe, { index: false }),
-    );
-  }
-
-  app.get('/', indexHandler);
-
   if (process.env.NODE_ENV === 'development') {
     const { createServer: createViteServer } = await import('vite');
     const vite = await createViteServer({
@@ -37,6 +28,14 @@ async function startServer() {
     app.use(vite.middlewares);
   }
 
+  if (process.env.NODE_ENV !== 'development') {
+    app.use(
+      '/familie/alene-med-barn/ettersending/',
+      express.static(frontendMappe, { index: false }),
+    );
+  }
+
+  app.get('/', indexHandler);
   app.get('/*splat', indexHandler);
 
   console.log('server listening on port', environment().port);

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useApp } from './context/AppContext';
+import { useApp } from './hooks/useApp';
 import {
   autentiseringsInterceptor,
   InnloggetStatus,

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -34,7 +34,9 @@ const lokalSøker: ISøker = {
 
 export const AppProvider = ({ children }: AppProviderProps) => {
   const [innloggetStatus, setInnloggetStatus] = useState<InnloggetStatus>(
-    InnloggetStatus.IKKE_VERIFISERT,
+    kjørerLokalt()
+      ? InnloggetStatus.AUTENTISERT
+      : InnloggetStatus.IKKE_VERIFISERT,
   );
 
   const [søker, settSøker] = useState<ISøker | null>(() => {

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -33,8 +33,9 @@ export const AppProvider = ({ children }: AppProviderProps) => {
         try {
           const personInfo = await hentPersoninfo();
           settSøker(personInfo.søker);
-        } catch {
-          console.warn('Klarte ikke hente søkerinfo');
+        } catch (e) {
+          console.warn('Klarte ikke hente søkerinfo', e);
+          setInnloggetStatus(InnloggetStatus.FEILET);
         }
       }
     };

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -30,8 +30,12 @@ export const AppProvider = ({ children }: AppProviderProps) => {
   useEffect(() => {
     const hentOgSettSøker = async () => {
       if (innloggetStatus === InnloggetStatus.AUTENTISERT) {
-        const personInfo = await hentPersoninfo();
-        settSøker(personInfo.søker);
+        try {
+          const personInfo = await hentPersoninfo();
+          settSøker(personInfo.søker);
+        } catch {
+          console.warn('Klarte ikke hente søkerinfo');
+        }
       }
     };
 

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -5,7 +5,6 @@ import {
 } from '../../shared-utils/autentisering';
 import { hentPersoninfo } from '../api-service';
 import { ISøker } from '../typer/søker';
-import { kjørerLokalt } from '../../shared-utils/miljø';
 
 interface AppContextType {
   innloggetStatus: InnloggetStatus;
@@ -18,38 +17,14 @@ interface AppProviderProps {
   children: React.ReactNode;
 }
 
-const lokalSøker: ISøker = {
-  forkortetNavn: 'Test Testesen',
-  fnr: '31458931375',
-  adresse: {
-    adresse: 'Testveien 1',
-    postnummer: '0001',
-    poststed: 'Oslo',
-  },
-  egenansatt: false,
-  erStrengtFortrolig: false,
-  siviltilstand: 'UGIFT',
-  statsborgerskap: 'NOR',
-};
-
 export const AppProvider = ({ children }: AppProviderProps) => {
   const [innloggetStatus, setInnloggetStatus] = useState<InnloggetStatus>(
-    kjørerLokalt()
-      ? InnloggetStatus.AUTENTISERT
-      : InnloggetStatus.IKKE_VERIFISERT,
+    InnloggetStatus.IKKE_VERIFISERT,
   );
-
-  const [søker, settSøker] = useState<ISøker | null>(() => {
-    if (kjørerLokalt()) {
-      return lokalSøker;
-    }
-    return null;
-  });
+  const [søker, settSøker] = useState<ISøker | null>(null);
 
   useEffect(() => {
-    if (!kjørerLokalt()) {
-      verifiserAtSøkerErAutentisert(setInnloggetStatus);
-    }
+    verifiserAtSøkerErAutentisert(setInnloggetStatus);
   }, []);
 
   useEffect(() => {

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -34,9 +34,7 @@ const lokalSøker: ISøker = {
 
 export const AppProvider = ({ children }: AppProviderProps) => {
   const [innloggetStatus, setInnloggetStatus] = useState<InnloggetStatus>(
-    kjørerLokalt()
-      ? InnloggetStatus.AUTENTISERT
-      : InnloggetStatus.IKKE_VERIFISERT,
+    InnloggetStatus.IKKE_VERIFISERT,
   );
 
   const [søker, settSøker] = useState<ISøker | null>(() => {
@@ -54,7 +52,7 @@ export const AppProvider = ({ children }: AppProviderProps) => {
 
   useEffect(() => {
     const hentOgSettSøker = async () => {
-      if (innloggetStatus === InnloggetStatus.AUTENTISERT && !kjørerLokalt()) {
+      if (innloggetStatus === InnloggetStatus.AUTENTISERT) {
         try {
           const personInfo = await hentPersoninfo();
           settSøker(personInfo.søker);

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -1,35 +1,60 @@
-import React, { useState, useEffect, createContext, useContext } from 'react';
+import React, { useState, useEffect, createContext } from 'react';
 import {
   InnloggetStatus,
   verifiserAtSøkerErAutentisert,
 } from '../../shared-utils/autentisering';
 import { hentPersoninfo } from '../api-service';
 import { ISøker } from '../typer/søker';
+import { kjørerLokalt } from '../../shared-utils/miljø';
 
 interface AppContextType {
   innloggetStatus: InnloggetStatus;
   søker: ISøker | null;
 }
 
-const AppContext = createContext<AppContextType | undefined>(undefined);
+export const AppContext = createContext<AppContextType | undefined>(undefined);
 
 interface AppProviderProps {
   children: React.ReactNode;
 }
 
+const lokalSøker: ISøker = {
+  forkortetNavn: 'Test Testesen',
+  fnr: '31458931375',
+  adresse: {
+    adresse: 'Testveien 1',
+    postnummer: '0001',
+    poststed: 'Oslo',
+  },
+  egenansatt: false,
+  erStrengtFortrolig: false,
+  siviltilstand: 'UGIFT',
+  statsborgerskap: 'NOR',
+};
+
 export const AppProvider = ({ children }: AppProviderProps) => {
   const [innloggetStatus, setInnloggetStatus] = useState<InnloggetStatus>(
-    InnloggetStatus.IKKE_VERIFISERT,
+    kjørerLokalt()
+      ? InnloggetStatus.AUTENTISERT
+      : InnloggetStatus.IKKE_VERIFISERT,
   );
-  const [søker, settSøker] = useState<ISøker | null>(null);
+
+  const [søker, settSøker] = useState<ISøker | null>(() => {
+    if (kjørerLokalt()) {
+      return lokalSøker;
+    }
+    return null;
+  });
 
   useEffect(() => {
-    verifiserAtSøkerErAutentisert(setInnloggetStatus);
+    if (!kjørerLokalt()) {
+      verifiserAtSøkerErAutentisert(setInnloggetStatus);
+    }
   }, []);
 
   useEffect(() => {
     const hentOgSettSøker = async () => {
-      if (innloggetStatus === InnloggetStatus.AUTENTISERT) {
+      if (innloggetStatus === InnloggetStatus.AUTENTISERT && !kjørerLokalt()) {
         try {
           const personInfo = await hentPersoninfo();
           settSøker(personInfo.søker);
@@ -48,13 +73,4 @@ export const AppProvider = ({ children }: AppProviderProps) => {
   };
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;
-};
-
-export const useApp = () => {
-  const context = useContext(AppContext);
-  if (context === undefined) {
-    throw new Error('useApp må brukes innenfor en AppProvider');
-  }
-
-  return context;
 };

--- a/src/frontend/hooks/useApp.ts
+++ b/src/frontend/hooks/useApp.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { AppContext } from '../context/AppContext';
+
+export const useApp = () => {
+  const context = useContext(AppContext);
+  if (context === undefined) {
+    throw new Error('useApp må brukes innenfor en AppProvider');
+  }
+
+  return context;
+};

--- a/src/frontend/komponenter/DokumentasjonsbehovListe.tsx
+++ b/src/frontend/komponenter/DokumentasjonsbehovListe.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useApp } from '../context/AppContext';
+import { useApp } from '../hooks/useApp';
 import { IDokumentasjonsbehov } from '../typer/ettersending';
 import { DokumentasjonsbehovBoks } from './DokumentasjonsbehovBoks';
 import { alertMelding } from './AlertStripe';

--- a/src/frontend/komponenter/Ettersendingsoversikt.tsx
+++ b/src/frontend/komponenter/Ettersendingsoversikt.tsx
@@ -5,7 +5,6 @@ import {
   hentEttersendinger,
   sendEttersending,
 } from '../api-service';
-import { InnloggetStatus } from '../../shared-utils/autentisering';
 import { kjørerLokalt } from '../../shared-utils/miljø';
 import {
   minstEttVedleggErLastetOpp,

--- a/src/frontend/komponenter/Ettersendingsoversikt.tsx
+++ b/src/frontend/komponenter/Ettersendingsoversikt.tsx
@@ -6,6 +6,7 @@ import {
   sendEttersending,
 } from '../api-service';
 import { InnloggetStatus } from '../../shared-utils/autentisering';
+import { kjørerLokalt } from '../../shared-utils/miljø';
 import {
   minstEttVedleggErLastetOpp,
   minstEnBoksErAvkrysset,
@@ -208,9 +209,9 @@ const Ettersendingsoversikt: React.FC = () => {
       }
     };
 
-    if (context.innloggetStatus === InnloggetStatus.AUTENTISERT)
+    if (context.søker != null || kjørerLokalt())
       hentOgSettSøknaderOgEttersendinger();
-  }, [context.innloggetStatus]);
+  }, [context.søker, context.innloggetStatus]);
 
   if (laster)
     return (

--- a/src/frontend/komponenter/Ettersendingsoversikt.tsx
+++ b/src/frontend/komponenter/Ettersendingsoversikt.tsx
@@ -199,7 +199,7 @@ const Ettersendingsoversikt: React.FC = () => {
 
         settEttersending({
           dokumentasjonsbehov: initielleInnsendinger,
-          personIdent: context.søker?.fnr ?? '',
+          personIdent: context.søker!.fnr,
         });
         settLasterverdi(false);
       } catch {

--- a/src/frontend/komponenter/Ettersendingsoversikt.tsx
+++ b/src/frontend/komponenter/Ettersendingsoversikt.tsx
@@ -5,6 +5,7 @@ import {
   hentEttersendinger,
   sendEttersending,
 } from '../api-service';
+import { InnloggetStatus } from '../../shared-utils/autentisering';
 import {
   minstEttVedleggErLastetOpp,
   minstEnBoksErAvkrysset,
@@ -162,49 +163,54 @@ const Ettersendingsoversikt: React.FC = () => {
 
   useEffect(() => {
     const hentOgSettSøknaderOgEttersendinger = async () => {
-      const søknadsliste = await hentSøknader();
-      const ettersendinger = await hentEttersendinger();
+      try {
+        const søknadsliste = await hentSøknader();
+        const ettersendinger = await hentEttersendinger();
 
-      const søknaderMedEttersendinger: ISøknadsbehov[] = søknadsliste.map(
-        (søknad: ISøknadsbehov) => {
-          return slåSammenSøknadOgEttersendinger(søknad, ettersendinger);
-        },
-      );
+        const søknaderMedEttersendinger: ISøknadsbehov[] = søknadsliste.map(
+          (søknad: ISøknadsbehov) => {
+            return slåSammenSøknadOgEttersendinger(søknad, ettersendinger);
+          },
+        );
 
-      const initielleInnsendinger: IDokumentasjonsbehov[] =
-        søknaderMedEttersendinger.flatMap((søknad) => {
-          return søknad.dokumentasjonsbehov.dokumentasjonsbehov
-            .filter(
-              (behov) =>
-                behov.opplastedeVedlegg.length === 0 && !behov.harSendtInn,
-            )
-            .map((behov) => {
-              return {
-                id: uuidv4(),
-                søknadsdata: {
-                  søknadId: søknad.søknadId,
-                  søknadsdato: søknad.søknadDato,
-                  dokumentasjonsbehovId: behov.id,
-                  harSendtInnTidligere: behov.harSendtInn,
-                },
-                dokumenttype: behov.id,
-                beskrivelse: behov.label,
-                stønadType: søknad.stønadType,
-                innsendingstidspunkt: dagensDatoMedTidspunktStreng(),
-                vedlegg: [],
-              };
-            });
+        const initielleInnsendinger: IDokumentasjonsbehov[] =
+          søknaderMedEttersendinger.flatMap((søknad) => {
+            return søknad.dokumentasjonsbehov.dokumentasjonsbehov
+              .filter(
+                (behov) =>
+                  behov.opplastedeVedlegg.length === 0 && !behov.harSendtInn,
+              )
+              .map((behov) => {
+                return {
+                  id: uuidv4(),
+                  søknadsdata: {
+                    søknadId: søknad.søknadId,
+                    søknadsdato: søknad.søknadDato,
+                    dokumentasjonsbehovId: behov.id,
+                    harSendtInnTidligere: behov.harSendtInn,
+                  },
+                  dokumenttype: behov.id,
+                  beskrivelse: behov.label,
+                  stønadType: søknad.stønadType,
+                  innsendingstidspunkt: dagensDatoMedTidspunktStreng(),
+                  vedlegg: [],
+                };
+              });
+          });
+
+        settEttersending({
+          dokumentasjonsbehov: initielleInnsendinger,
+          personIdent: context.søker?.fnr ?? '',
         });
-
-      settEttersending({
-        dokumentasjonsbehov: initielleInnsendinger,
-        personIdent: context.søker!.fnr,
-      });
-      settLasterverdi(false);
+        settLasterverdi(false);
+      } catch {
+        settLasterverdi(false);
+      }
     };
 
-    if (context.søker != null) hentOgSettSøknaderOgEttersendinger();
-  }, [context.søker]);
+    if (context.innloggetStatus === InnloggetStatus.AUTENTISERT)
+      hentOgSettSøknaderOgEttersendinger();
+  }, [context.innloggetStatus]);
 
   if (laster)
     return (

--- a/src/frontend/komponenter/Ettersendingsoversikt.tsx
+++ b/src/frontend/komponenter/Ettersendingsoversikt.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useApp } from '../context/AppContext';
+import { useApp } from '../hooks/useApp';
 import {
   hentSøknader,
   hentEttersendinger,
   sendEttersending,
 } from '../api-service';
-import { kjørerLokalt } from '../../shared-utils/miljø';
 import {
   minstEttVedleggErLastetOpp,
   minstEnBoksErAvkrysset,
@@ -208,9 +207,8 @@ const Ettersendingsoversikt: React.FC = () => {
       }
     };
 
-    if (context.søker != null || kjørerLokalt())
-      hentOgSettSøknaderOgEttersendinger();
-  }, [context.søker, context.innloggetStatus]);
+    if (context.søker != null) hentOgSettSøknaderOgEttersendinger();
+  }, [context.søker]);
 
   if (laster)
     return (

--- a/src/shared-utils/autentisering.ts
+++ b/src/shared-utils/autentisering.ts
@@ -27,7 +27,7 @@ export const autentiseringsInterceptor = () => {
       return response;
     },
     (error: AxiosError) => {
-      if (er401Feil(error)) {
+      if (er401Feil(error) && !isLocal()) {
         window.location.href = getLoginUrl();
       } else {
         throw error;
@@ -39,13 +39,23 @@ export const autentiseringsInterceptor = () => {
 export const verifiserAtSøkerErAutentisert = (
   settAutentisering: Dispatch<SetStateAction<InnloggetStatus>>,
 ) => {
-  return verifiserInnloggetApi().then((response) => {
-    if (response && 200 === response.status) {
-      settAutentisering(InnloggetStatus.AUTENTISERT);
-    } else {
-      settAutentisering(InnloggetStatus.FEILET);
-    }
-  });
+  return verifiserInnloggetApi()
+    .then((response) => {
+      if (response && 200 === response.status) {
+        settAutentisering(InnloggetStatus.AUTENTISERT);
+      } else {
+        settAutentisering(InnloggetStatus.FEILET);
+      }
+    })
+    .catch((error) => {
+      if (isLocal()) {
+        console.warn('Autentisering feilet lokalt');
+        settAutentisering(InnloggetStatus.AUTENTISERT);
+      } else {
+        settAutentisering(InnloggetStatus.FEILET);
+        throw error;
+      }
+    });
 };
 
 const verifiserInnloggetApi = () => {

--- a/src/shared-utils/autentisering.ts
+++ b/src/shared-utils/autentisering.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import { Dispatch, SetStateAction } from 'react';
-import environment, { isLocal } from '../backend/environment';
+import environment, { isLocal } from '../backend/environment.js';
 
 export enum InnloggetStatus {
   AUTENTISERT = 'innlogget',
@@ -47,14 +47,8 @@ export const verifiserAtSøkerErAutentisert = (
         settAutentisering(InnloggetStatus.FEILET);
       }
     })
-    .catch((error) => {
-      if (isLocal()) {
-        console.warn('Autentisering feilet lokalt');
-        settAutentisering(InnloggetStatus.AUTENTISERT);
-      } else {
-        settAutentisering(InnloggetStatus.FEILET);
-        throw error;
-      }
+    .catch(() => {
+      settAutentisering(InnloggetStatus.FEILET);
     });
 };
 


### PR DESCRIPTION
- Fikser HTML parser feil fra dekorator - fjerner </link> ugyldig tag
- Endret rekkefølge på vite og express -  vite før catch-all route for å unngå at "Upgrade Required" var det eneste som ble vist
- Splittet AppContext og useApp, det ga feil fra Vite HMR
- soknad-api generere nå token fra fakedings, som ettersending forventer, får nå søkerinfo lokalt [PR for soknad-api](https://github.com/navikt/familie-ef-soknad-api/pull/1282)

