### PR TITLE
Små forbedringer - bedre brukeropplevelsen

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -18,7 +18,7 @@ const App: React.FC = () => {
     return (
       <div className={styles.bakgrunn}>
         <div className={styles.container}>
-          <VStack gap={'space-8'}>
+          <VStack gap={'space-24'}>
             <VStack align={'center'}>
               <div>
                 <img

--- a/src/frontend/komponenter/DokumentasjonsbehovBoks.tsx
+++ b/src/frontend/komponenter/DokumentasjonsbehovBoks.tsx
@@ -39,7 +39,7 @@ export const DokumentasjonsbehovBoks: React.FC<Props> = ({
 
   return (
     <Box padding="space-8" borderWidth="1">
-      <VStack gap={'space-4'}>
+      <VStack gap={'space-8'}>
         <HStack gap={'space-4'}>
           {dokumentasjonErOpplastet ? (
             <CheckmarkCircleIcon

--- a/src/frontend/komponenter/Ettersendingsoversikt.tsx
+++ b/src/frontend/komponenter/Ettersendingsoversikt.tsx
@@ -24,7 +24,7 @@ import { Oppsummering } from './Oppsummering';
 import { InnsendingSide } from './InnsendingSide';
 import { slåSammenSøknadOgEttersendinger } from '../utils/søknadshåndtering';
 import { EOppsummeringstitler } from '../utils/oppsummeringssteg';
-import { Button, HStack, Loader, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, HStack, Loader, VStack } from '@navikt/ds-react';
 import Stegindikator from './Stegindikator';
 
 const Ettersendingsoversikt: React.FC = () => {
@@ -44,6 +44,7 @@ const Ettersendingsoversikt: React.FC = () => {
     settEkstraInnsendingerSomManglerVedlegg,
   ] = useState<string[]>([]);
   const [aktivtSteg, settAktivtSteg] = useState<number>(0);
+  const [senderInn, settSenderInn] = useState(false);
 
   const stegForInnsending = [
     {
@@ -147,6 +148,7 @@ const Ettersendingsoversikt: React.FC = () => {
   const sendInnEttersending = async () => {
     try {
       settAktivtSteg(2);
+      settSenderInn(true);
       const ettersendingTilBackend: IEttersending = {
         dokumentasjonsbehov: filtrerUtfylteInnsendinger(ettersending),
         personIdent: ettersending.personIdent,
@@ -155,6 +157,8 @@ const Ettersendingsoversikt: React.FC = () => {
       settAlertStripeMelding(alertMelding.SENDT_INN);
     } catch {
       settAlertStripeMelding(alertMelding.FEIL_VED_INNSENDING);
+    } finally {
+      settSenderInn(false);
     }
   };
 
@@ -257,10 +261,19 @@ const Ettersendingsoversikt: React.FC = () => {
       )}
 
       {aktivtSteg === 2 && (
-        <Oppsummering
-          tittel={EOppsummeringstitler.Kvittering}
-          innsendinger={filtrerUtfylteInnsendinger(ettersending)}
-        />
+        <>
+          <Oppsummering
+            tittel={EOppsummeringstitler.Kvittering}
+            innsendinger={filtrerUtfylteInnsendinger(ettersending)}
+          />
+
+          {senderInn && (
+            <HStack align={'center'} gap={'space-12'}>
+              <Loader size={'xlarge'} title={'Sender inn dokumentasjon'} />
+              <BodyShort>Dokumentasjon sendes inn...</BodyShort>
+            </HStack>
+          )}
+        </>
       )}
 
       <AlertStripe melding={alertStripeMelding} />

--- a/src/frontend/komponenter/InnsendingSide.tsx
+++ b/src/frontend/komponenter/InnsendingSide.tsx
@@ -27,6 +27,10 @@ export const InnsendingSide: React.FC<IProps> = ({
   ekstraInnsendingerUtenVedlegg,
   settAlertStripeMelding,
 }: IProps) => {
+  const harLastetOppNoenVedlegg = ettersending.dokumentasjonsbehov.some(
+    (innsending) => innsending.vedlegg.length > 0,
+  );
+
   return (
     <>
       {ettersending.dokumentasjonsbehov
@@ -67,7 +71,9 @@ export const InnsendingSide: React.FC<IProps> = ({
       </Button>
 
       <VStack align={'center'} justify={'space-between'}>
-        <Button onClick={visOppsummering}>Neste</Button>
+        <Button onClick={visOppsummering} disabled={!harLastetOppNoenVedlegg}>
+          Neste
+        </Button>
       </VStack>
     </>
   );

--- a/src/frontend/komponenter/OpplastedeVedlegg.tsx
+++ b/src/frontend/komponenter/OpplastedeVedlegg.tsx
@@ -43,7 +43,7 @@ export const OpplastedeVedlegg: React.FC<IOpplastedeVedlegg> = ({
             key={fil.id}
             file={{
               name: fil.navn.replace(/_/g, '-'),
-              size: fil.størrelse,
+              size: fil.størrelse ?? 0,
             }}
             onFileClick={() => visDokumentNyFane(fil)}
             href="#"

--- a/src/frontend/komponenter/OpplastedeVedlegg.tsx
+++ b/src/frontend/komponenter/OpplastedeVedlegg.tsx
@@ -4,7 +4,7 @@ import { base64toBlob, åpnePdfIEgenTab } from '../utils/filer';
 import { hentOpplastetVedlegg } from '../api-service';
 import { RessursStatus } from '../typer/ressurs';
 import AlertStripe, { alertMelding } from './AlertStripe';
-import { FileUpload } from '@navikt/ds-react';
+import { FileUpload, VStack } from '@navikt/ds-react';
 
 interface IOpplastedeVedlegg {
   vedleggsliste: IVedleggForEttersending[];
@@ -36,24 +36,24 @@ export const OpplastedeVedlegg: React.FC<IOpplastedeVedlegg> = ({
 
   return (
     <>
-      <ul>
+      <VStack as="ul" gap="space-12">
         {vedleggsliste.map((fil: IVedleggForEttersending) => (
-          <li key={fil.id}>
-            <FileUpload.Item
-              file={{
-                name: fil.navn.replace(/_/g, '-'),
-                size: 0,
-              }}
-              onFileClick={() => visDokumentNyFane(fil)}
-              href="#"
-              button={{
-                action: 'delete',
-                onClick: () => slettVedlegg(fil),
-              }}
-            />
-          </li>
+          <FileUpload.Item
+            as="li"
+            key={fil.id}
+            file={{
+              name: fil.navn.replace(/_/g, '-'),
+              size: fil.størrelse,
+            }}
+            onFileClick={() => visDokumentNyFane(fil)}
+            href="#"
+            button={{
+              action: 'delete',
+              onClick: () => slettVedlegg(fil),
+            }}
+          />
         ))}
-      </ul>
+      </VStack>
 
       {feilmelding && <AlertStripe melding={feilmelding} />}
     </>

--- a/src/frontend/komponenter/Vedleggsopplaster.tsx
+++ b/src/frontend/komponenter/Vedleggsopplaster.tsx
@@ -63,7 +63,7 @@ const Vedleggsopplaster: React.FC<IProps> = ({
         </ModalWrapper>
       )}
 
-      <VStack gap={'space-2'}>
+      <VStack gap={'space-8'}>
         {innsending.vedlegg.length === 0 && (
           <VStack align={'center'} justify={'space-between'}>
             {slettInnsedning && (

--- a/src/frontend/komponenter/Vedleggsvelger.tsx
+++ b/src/frontend/komponenter/Vedleggsvelger.tsx
@@ -177,7 +177,7 @@ const Vedleggsvelger: React.FC<IProps> = ({
 
         <FileUpload.Dropzone
           label="Velg filer"
-          description="Du kan laste opp PDF-, og bildefiler"
+          description="Du kan laste opp PDF-, PNG- og JPG-filer"
           accept={tillateFiltyperAccept}
           maxSizeInBytes={maxFilstørrelse}
           validator={validerFil}

--- a/src/frontend/komponenter/Vedleggsvelger.tsx
+++ b/src/frontend/komponenter/Vedleggsvelger.tsx
@@ -125,6 +125,7 @@ const Vedleggsvelger: React.FC<IProps> = ({
             id: respons,
             navn: fil.name,
             tittel: innsending.beskrivelse || 'Ukjent tittel',
+            størrelse: fil.size,
           };
           vedleggListe.push(vedlegg);
         } catch (error: unknown) {
@@ -163,7 +164,7 @@ const Vedleggsvelger: React.FC<IProps> = ({
 
   return (
     <Box margin={'space-4'}>
-      <VStack gap={'space-2'}>
+      <VStack gap={'space-16'}>
         <Heading level={'1'} size={'xsmall'}>
           {beskrivelse}
         </Heading>
@@ -201,13 +202,10 @@ const Vedleggsvelger: React.FC<IProps> = ({
         <BodyShort size={'small'}>
           Hvis dokumentet du skal sende inn består av flere filer, kan du legge
           til alle filene her.
+          {skalDokumenttypeSlåsSammen(innsending.dokumenttype) && (
+            <> Filene blir slått sammen til ett dokument.</>
+          )}
         </BodyShort>
-
-        {skalDokumenttypeSlåsSammen(innsending.dokumenttype) && (
-          <BodyShort size={'small'}>
-            Filene blir slått sammen til ett dokument.
-          </BodyShort>
-        )}
 
         <AlertStripe melding={alertStripeMelding} />
 

--- a/src/frontend/typer/ettersending.ts
+++ b/src/frontend/typer/ettersending.ts
@@ -44,4 +44,5 @@ export interface IVedleggForEttersending {
   id: string;
   navn: string;
   tittel: string;
+  størrelse?: number;
 }


### PR DESCRIPTION
Generelt mer luft mellom innhold slik at det blir enklere å skille og mer tydelig.
Disabler knapp slik at bruker ikke kan trykke neste før noe er dokumentasjon er valgt lastet opp.
Viser spinner og tekst mens dokumentasjon forsøkes å lastes opp for å gi tilbakemelding til bruker før alert vises.

Før:
<img width="1047" height="1317" alt="image" src="https://github.com/user-attachments/assets/9b67c735-6f6e-40df-8052-2ae611b89c4f" />


Etter:
<img width="1049" height="1320" alt="image" src="https://github.com/user-attachments/assets/907a45d5-d401-4a3f-83c8-3d05b6490f0f" />
