### PR TITLE
Fjerner Axios - bruker Fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@navikt/ds-css": "8.15.0",
         "@navikt/ds-react": "8.15.0",
         "@navikt/nav-dekoratoren-moduler": "4.2.2",
-        "axios": "1.18.1",
         "date-fns": "4.4.0",
         "express": "5.2.1",
         "http-proxy-middleware": "3.0.5",
@@ -2000,18 +1999,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2178,10 +2165,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "dev": true,
@@ -2194,18 +2177,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2474,16 +2445,6 @@
         "node": ">=14.6"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -2666,13 +2627,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -2931,6 +2885,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3457,20 +3412,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "license": "MIT",
@@ -3703,6 +3644,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3853,19 +3795,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -4525,23 +4454,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types/node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4916,15 +4828,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@navikt/ds-css": "8.15.0",
     "@navikt/ds-react": "8.15.0",
     "@navikt/nav-dekoratoren-moduler": "4.2.2",
-    "axios": "1.18.1",
     "date-fns": "4.4.0",
     "express": "5.2.1",
     "http-proxy-middleware": "3.0.5",

--- a/src/backend/texas.ts
+++ b/src/backend/texas.ts
@@ -1,16 +1,20 @@
 import { envVar } from './envVar.js';
-import axios from 'axios';
 import logger from './logger.js';
 
 export class TexasClient {
   private async postRequest(url: string, data: object) {
     try {
-      const response = await axios.post(url, data, {
+      const response = await fetch(url, {
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify(data),
       });
-      return response.data;
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.json();
     } catch (error) {
       logger.error(`Request mot ${url} feilet.`, error);
       throw error;

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { useApp } from './hooks/useApp';
-import {
-  autentiseringsInterceptor,
-  InnloggetStatus,
-} from '../shared-utils/autentisering';
+import { InnloggetStatus } from '../shared-utils/autentisering';
 import sjekklisteikon from './icons/sjekklisteikon.svg';
 import Ettersendingsoversikt from './komponenter/Ettersendingsoversikt';
 import { BodyLong, Heading, Loader, VStack } from '@navikt/ds-react';
@@ -11,8 +8,6 @@ import styles from './App.module.css';
 
 const App: React.FC = () => {
   const context = useApp();
-
-  autentiseringsInterceptor();
 
   if (context.innloggetStatus === InnloggetStatus.AUTENTISERT) {
     return (

--- a/src/frontend/api-service.ts
+++ b/src/frontend/api-service.ts
@@ -1,8 +1,8 @@
-import axios from 'axios';
 import environment from '../backend/environment';
 import { IEttersending, ISøknadsbehov } from './typer/ettersending';
 import { IPersoninfo } from './typer/søker';
 import { Ressurs } from './typer/ressurs';
+import { håndter401 } from '../shared-utils/autentisering';
 
 interface Ifamilievedlegg {
   dokumentId: string;
@@ -17,99 +17,105 @@ interface IKvittering {
 const HEADER_NAV_CONSUMER_ID = 'Nav-Consumer-Id';
 const HEADER_NAV_CONSUMER_ID_VALUE = 'familie-ef-ettersending';
 
+const HEADER_NAV_CONSUMER = {
+  [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
+};
+
+export interface ApiError extends Error {
+  status: number;
+  data?: unknown;
+}
+
+const håndterRespons = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    håndter401(response);
+    const errorBody = await response.json().catch(() => undefined);
+    const error = new Error(
+      `HTTP ${response.status}: ${response.statusText}`,
+    ) as ApiError;
+    error.status = response.status;
+    error.data = errorBody;
+    throw error;
+  }
+  return response.json() as Promise<T>;
+};
+
 export const sendEttersending = (
   ettersendingsdata: IEttersending,
 ): Promise<IKvittering> => {
-  return axios
-    .post(`${environment().apiProxyUrl}/api/ettersending`, ettersendingsdata, {
-      withCredentials: true,
-      headers: {
-        [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
-      },
-    })
-    .then((response) => response.data);
+  return fetch(`${environment().apiProxyUrl}/api/ettersending`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...HEADER_NAV_CONSUMER,
+    },
+    body: JSON.stringify(ettersendingsdata),
+  }).then(håndterRespons<IKvittering>);
 };
 
 export const hentEttersendinger = (): Promise<IEttersending[]> => {
-  return axios
-    .get(`${environment().apiProxyUrl}/api/ettersending`, {
-      withCredentials: true,
-      headers: {
-        [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
-      },
-    })
-    .then((response: { data: IEttersending[] }) => response.data);
+  return fetch(`${environment().apiProxyUrl}/api/ettersending`, {
+    credentials: 'include',
+    headers: HEADER_NAV_CONSUMER,
+  }).then(håndterRespons<IEttersending[]>);
 };
 
 export const hentOpplastetVedlegg = (
   dokumentId: string,
 ): Promise<Ressurs<string>> => {
-  return axios
-    .get(
-      `${
-        environment().dokumentProxyUrl
-      }/dokument/api/mapper/familievedlegg/${dokumentId}`,
-      {
-        withCredentials: true,
-        headers: {
-          [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
-        },
-      },
-    )
-    .then((response: { data: Ressurs<string> }) => response.data);
+  return fetch(
+    `${environment().dokumentProxyUrl}/dokument/api/mapper/familievedlegg/${dokumentId}`,
+    {
+      credentials: 'include',
+      headers: HEADER_NAV_CONSUMER,
+    },
+  ).then(håndterRespons<Ressurs<string>>);
 };
 
 export const hentPersoninfo = (): Promise<IPersoninfo> => {
-  return axios
-    .get(`${environment().apiProxyUrl}/api/oppslag/sokerinfo`, {
-      withCredentials: true,
-      headers: {
-        [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
-      },
-    })
-    .then((response: { data: IPersoninfo }) => response.data);
+  return fetch(`${environment().apiProxyUrl}/api/oppslag/sokerinfo`, {
+    credentials: 'include',
+    headers: HEADER_NAV_CONSUMER,
+  }).then(håndterRespons<IPersoninfo>);
 };
 
 export const hentSøknader = (): Promise<ISøknadsbehov[]> => {
-  return axios
-    .get(`${environment().apiProxyUrl}/api/dokumentasjonsbehov/person`, {
-      withCredentials: true,
-      headers: {
-        [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
-      },
-    })
-    .then((response: { data: ISøknadsbehov[] }) => response.data);
+  return fetch(`${environment().apiProxyUrl}/api/dokumentasjonsbehov/person`, {
+    credentials: 'include',
+    headers: HEADER_NAV_CONSUMER,
+  }).then(håndterRespons<ISøknadsbehov[]>);
 };
 
 export const sendVedleggTilMellomlager = (
   formData: FormData,
 ): Promise<string> => {
-  return axios
-    .post(
-      `${environment().dokumentProxyUrl}/dokument/api/mapper/familievedlegg`,
-      formData,
-      {
-        headers: {
-          'content-type': 'multipart/form-data',
-          [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
-        },
-        withCredentials: true,
-      },
-    )
-    .then((response: { data: Ifamilievedlegg }) => response.data.dokumentId);
+  return fetch(
+    `${environment().dokumentProxyUrl}/dokument/api/mapper/familievedlegg`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: HEADER_NAV_CONSUMER,
+      body: formData,
+    },
+  )
+    .then(håndterRespons<Ifamilievedlegg>)
+    .then((data) => data.dokumentId);
 };
 
 export const slåSammenVedlegg = (dokumentIder: string[]): Promise<string> => {
-  return axios
-    .post(
-      `${environment().dokumentProxyUrl}/dokument/api/mapper/merge/familievedlegg`,
-      dokumentIder,
-      {
-        headers: {
-          [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
-        },
-        withCredentials: true,
+  return fetch(
+    `${environment().dokumentProxyUrl}/dokument/api/mapper/merge/familievedlegg`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        ...HEADER_NAV_CONSUMER,
       },
-    )
-    .then((response: { data: Ifamilievedlegg }) => response.data.dokumentId);
+      body: JSON.stringify(dokumentIder),
+    },
+  )
+    .then(håndterRespons<Ifamilievedlegg>)
+    .then((data) => data.dokumentId);
 };

--- a/src/frontend/komponenter/Vedleggsvelger.tsx
+++ b/src/frontend/komponenter/Vedleggsvelger.tsx
@@ -133,8 +133,7 @@ const Vedleggsvelger: React.FC<IProps> = ({
           vedleggListe.push(vedlegg);
         } catch (error: unknown) {
           const data = (error as ApiError).data as
-            | Record<string, unknown>
-            | undefined;
+            Record<string, unknown> | undefined;
           const erForLitenFil =
             data?.melding === 'CODE=IMAGE_DIMENSIONS_TOO_SMALL';
           settAlertStripeMelding(

--- a/src/frontend/komponenter/Vedleggsvelger.tsx
+++ b/src/frontend/komponenter/Vedleggsvelger.tsx
@@ -132,16 +132,14 @@ const Vedleggsvelger: React.FC<IProps> = ({
           };
           vedleggListe.push(vedlegg);
         } catch (error: unknown) {
+          const data = (error as ApiError).data as
+            | Record<string, unknown>
+            | undefined;
           const erForLitenFil =
-            (error as ApiError).data &&
-            typeof (error as ApiError).data === 'object' &&
-            (error as ApiError).data !== null &&
-            ((error as ApiError).data as Record<string, unknown>).melding ===
-              'CODE=IMAGE_DIMENSIONS_TOO_SMALL';
-          const feilmelding = erForLitenFil
-            ? alertMelding.FEIL_FOR_LITEN_FIL
-            : alertMelding.FEIL;
-          settAlertStripeMelding(feilmelding);
+            data?.melding === 'CODE=IMAGE_DIMENSIONS_TOO_SMALL';
+          settAlertStripeMelding(
+            erForLitenFil ? alertMelding.FEIL_FOR_LITEN_FIL : alertMelding.FEIL,
+          );
         }
       }),
     );

--- a/src/frontend/komponenter/Vedleggsvelger.tsx
+++ b/src/frontend/komponenter/Vedleggsvelger.tsx
@@ -4,7 +4,11 @@ import {
   IDokumentasjonsbehov,
   IVedleggForEttersending,
 } from '../typer/ettersending';
-import { sendVedleggTilMellomlager, slåSammenVedlegg } from '../api-service';
+import {
+  sendVedleggTilMellomlager,
+  slåSammenVedlegg,
+  ApiError,
+} from '../api-service';
 import AlertStripe, { alertMelding } from './AlertStripe';
 import {
   formaterFilstørrelse,
@@ -12,7 +16,6 @@ import {
   tillateFiltyperAccept,
 } from '../utils/filer';
 import { DokumentType, StønadType, stønadTypeTilTekst } from '../typer/stønad';
-import axios from 'axios';
 import {
   Box,
   Button,
@@ -129,11 +132,15 @@ const Vedleggsvelger: React.FC<IProps> = ({
           };
           vedleggListe.push(vedlegg);
         } catch (error: unknown) {
-          const feilmelding =
-            axios.isAxiosError(error) &&
-            error?.response?.data?.melding === 'CODE=IMAGE_DIMENSIONS_TOO_SMALL'
-              ? alertMelding.FEIL_FOR_LITEN_FIL
-              : alertMelding.FEIL;
+          const erForLitenFil =
+            (error as ApiError).data &&
+            typeof (error as ApiError).data === 'object' &&
+            (error as ApiError).data !== null &&
+            ((error as ApiError).data as Record<string, unknown>).melding ===
+              'CODE=IMAGE_DIMENSIONS_TOO_SMALL';
+          const feilmelding = erForLitenFil
+            ? alertMelding.FEIL_FOR_LITEN_FIL
+            : alertMelding.FEIL;
           settAlertStripeMelding(feilmelding);
         }
       }),

--- a/src/shared-utils/autentisering.ts
+++ b/src/shared-utils/autentisering.ts
@@ -31,6 +31,7 @@ export const verifiserAtSøkerErAutentisert = (
       if (response.ok) {
         settAutentisering(InnloggetStatus.AUTENTISERT);
       } else {
+        håndter401(response);
         settAutentisering(InnloggetStatus.FEILET);
       }
     })

--- a/src/shared-utils/autentisering.ts
+++ b/src/shared-utils/autentisering.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosError } from 'axios';
 import { Dispatch, SetStateAction } from 'react';
 import environment, { isLocal } from '../backend/environment.js';
 
@@ -7,9 +6,6 @@ export enum InnloggetStatus {
   FEILET = 'ikke logget inn (innlogging feilet)',
   IKKE_VERIFISERT = 'ikke logget inn',
 }
-
-const er401Feil = (error: AxiosError) =>
-  error && error.response && error.response.status === 401;
 
 const getLoginUrl = () => {
   if (isLocal()) {
@@ -21,19 +17,10 @@ const getLoginUrl = () => {
   );
 };
 
-export const autentiseringsInterceptor = () => {
-  axios.interceptors.response.use(
-    (response) => {
-      return response;
-    },
-    (error: AxiosError) => {
-      if (er401Feil(error) && !isLocal()) {
-        window.location.href = getLoginUrl();
-      } else {
-        throw error;
-      }
-    },
-  );
+export const håndter401 = (response: Response): void => {
+  if (response.status === 401 && !isLocal()) {
+    window.location.href = getLoginUrl();
+  }
 };
 
 export const verifiserAtSøkerErAutentisert = (
@@ -41,7 +28,7 @@ export const verifiserAtSøkerErAutentisert = (
 ) => {
   return verifiserInnloggetApi()
     .then((response) => {
-      if (response && 200 === response.status) {
+      if (response.ok) {
         settAutentisering(InnloggetStatus.AUTENTISERT);
       } else {
         settAutentisering(InnloggetStatus.FEILET);
@@ -53,7 +40,7 @@ export const verifiserAtSøkerErAutentisert = (
 };
 
 const verifiserInnloggetApi = () => {
-  return axios.get(`${environment().apiProxyUrl}/api/innlogget`, {
-    withCredentials: true,
+  return fetch(`${environment().apiProxyUrl}/api/innlogget`, {
+    credentials: 'include',
   });
 };


### PR DESCRIPTION
Skriver om til å bruke fetch i stedet for axios, for å bli kvitt en avhengighet

- Alle HTTP-kall bruker fetch. Felles håndterRespons<T>() med typet ApiError, parser error body fra backend, håndterer 401-redirect.

Testet mot dev ✅ 