### PR TITLE
Fix logging

### DIFF
--- a/src/backend/logger.ts
+++ b/src/backend/logger.ts
@@ -4,7 +4,10 @@ import { Request } from 'express';
 const logger = winston.createLogger({
   transports: [
     new winston.transports.Console({
-      format: winston.format.json(),
+      format: winston.format.combine(
+        winston.format.splat(),
+        winston.format.json(),
+      ),
     }),
   ],
 });


### PR DESCRIPTION
Logger i prod viser: `[HPM] Error occurred while proxying request %s to %s [%s] (%s)`
Fikser loggen slik at faktiske verdier blir printet ut, og ikke bare %s.